### PR TITLE
Add @types/node

### DIFF
--- a/projects/frontend/package.json
+++ b/projects/frontend/package.json
@@ -14,6 +14,7 @@
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@types/eslint": "8.56.0",
+    "@types/node": "^20.11.16",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "chromatic": "^10.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3738,6 +3738,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^20.11.16":
+  version: 20.11.16
+  resolution: "@types/node@npm:20.11.16"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 4886b90278e9c877a84efd3edd4667cd990e032d77268d2a798b99ebc1901ea336fa7dfbe9eaf4ad6ad1da9ce2ec31baf300038a3905838692362eb19904ebde
+  languageName: node
+  linkType: hard
+
 "@types/normalize-package-data@npm:^2.4.0":
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
@@ -4646,6 +4655,7 @@ __metadata:
     "@sveltejs/kit": "npm:^2.0.0"
     "@sveltejs/vite-plugin-svelte": "npm:^3.0.0"
     "@types/eslint": "npm:8.56.0"
+    "@types/node": "npm:^20.11.16"
     "@typescript-eslint/eslint-plugin": "npm:^6.0.0"
     "@typescript-eslint/parser": "npm:^6.0.0"
     "@vercel/analytics": "npm:^1.1.2"


### PR DESCRIPTION
Fixes yarn warning 
```
➤ YN0002: │ button@workspace:projects/frontend doesn't provide @types/node (p01f57), requested by ts-node.
```