### PR TITLE
Add root tsconfig.json

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -15,5 +15,4 @@ node:
 
 typescript:
   routeOutDirToCache: true
-  syncProjectReferences: true
-  syncProjectReferencesToPaths: true
+  syncProjectReferences: false

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -12,10 +12,8 @@ $schema: "https://moonrepo.dev/schemas/workspace.json"
 # path to the project folder as the map value. File paths are relative from the workspace root,
 # and cannot reference projects located outside the workspace boundary.
 projects:
-  globs:
-    - "projects/*"
-  sources:
-    root: "."
+  - "projects/*"
+  - "."
 
 vcs:
   defaultBranch: "main"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "outDir": ".moon/cache/types",
+  },
+}


### PR DESCRIPTION
This also turns off project reference syncing and path syncing, I'm not sure if these will be useful—it's a bit hard to evaluate until there is actually more than one TypeScript project.