### PR TITLE
Organize imports in migrate.ts

### DIFF
--- a/projects/frontend/src/bin/migrate.ts
+++ b/projects/frontend/src/bin/migrate.ts
@@ -1,10 +1,10 @@
+import { sql } from "@vercel/postgres";
+import type { MigrationConfig } from "drizzle-orm/migrator";
 import { drizzle as pgDrizzle } from "drizzle-orm/postgres-js";
 import { migrate as pgMigrate } from "drizzle-orm/postgres-js/migrator";
 import { drizzle as vercelDrizzle } from "drizzle-orm/vercel-postgres";
 import { migrate as vercelMigrate } from "drizzle-orm/vercel-postgres/migrator";
-import { sql } from "@vercel/postgres";
 import postgres from "postgres";
-import type { MigrationConfig } from "drizzle-orm/migrator";
 
 const migrationConfig = { migrationsFolder: "drizzle" } satisfies MigrationConfig;
 


### PR DESCRIPTION
Semantic conflict, I merged organise imports PR, then @bradleyayers merged a new file `migrate.ts` that didn't get run through the new prettier config.