### PR TITLE
Use moon via proto (properly)

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,2 +1,4 @@
+moon = "1.21.2"
+
 [plugins]
 moon = "source:https://raw.githubusercontent.com/moonrepo/moon/master/proto-plugin.toml"

--- a/README.md
+++ b/README.md
@@ -2,29 +2,22 @@
 
 [![CI](https://github.com/bradleyayers/haohaohow/actions/workflows/ci.yml/badge.svg)](https://github.com/bradleyayers/haohaohow/actions/workflows/ci.yml)
 
-# Setup
+## Setup
 
-- Install `proto`
+Install [proto](https://moonrepo.dev/proto):
 
 ```sh
-$ curl -fsSL https://moonrepo.dev/install/proto.sh | bash
+curl -fsSL https://moonrepo.dev/install/proto.sh | bash
 ```
 
-- Install `node`
+Install other tools used in the workspace:
 
 ```sh
-$ proto install node 21
+proto use
 ```
 
-- Install `moon`
+## Running scripts with moon
 
 ```sh
-$ proto tool add moon "source:https://raw.githubusercontent.com/moonrepo/moon/master/proto-plugin.toml"
-$ proto install moon
-```
-
-# Running scripts with moon
-
-```sh
-$ moon frontend:build
+moon frontend:build
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "projects/*"
   ],
   "devDependencies": {
-    "@moonrepo/cli": "^1.19.3",
     "@yarnpkg/doctor": "^4.0.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,88 +2488,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@moonrepo/cli@npm:^1.19.3":
-  version: 1.19.3
-  resolution: "@moonrepo/cli@npm:1.19.3"
-  dependencies:
-    "@moonrepo/core-linux-arm64-gnu": "npm:1.19.3"
-    "@moonrepo/core-linux-arm64-musl": "npm:1.19.3"
-    "@moonrepo/core-linux-x64-gnu": "npm:1.19.3"
-    "@moonrepo/core-linux-x64-musl": "npm:1.19.3"
-    "@moonrepo/core-macos-arm64": "npm:1.19.3"
-    "@moonrepo/core-macos-x64": "npm:1.19.3"
-    "@moonrepo/core-windows-x64-msvc": "npm:1.19.3"
-    detect-libc: "npm:^2.0.2"
-  dependenciesMeta:
-    "@moonrepo/core-linux-arm64-gnu":
-      optional: true
-    "@moonrepo/core-linux-arm64-musl":
-      optional: true
-    "@moonrepo/core-linux-x64-gnu":
-      optional: true
-    "@moonrepo/core-linux-x64-musl":
-      optional: true
-    "@moonrepo/core-macos-arm64":
-      optional: true
-    "@moonrepo/core-macos-x64":
-      optional: true
-    "@moonrepo/core-windows-x64-msvc":
-      optional: true
-  bin:
-    moon: moon
-  checksum: 8eb298851fa6c6fb51cd70db1e1ec252aa4f320dc6649a7bf1d6fe2b6197824df91ade4d947bdabbb0f0b658bde73f4edb3a8e57a459cc40b22b6c84133c64fb
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-linux-arm64-gnu@npm:1.19.3":
-  version: 1.19.3
-  resolution: "@moonrepo/core-linux-arm64-gnu@npm:1.19.3"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-linux-arm64-musl@npm:1.19.3":
-  version: 1.19.3
-  resolution: "@moonrepo/core-linux-arm64-musl@npm:1.19.3"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-linux-x64-gnu@npm:1.19.3":
-  version: 1.19.3
-  resolution: "@moonrepo/core-linux-x64-gnu@npm:1.19.3"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-linux-x64-musl@npm:1.19.3":
-  version: 1.19.3
-  resolution: "@moonrepo/core-linux-x64-musl@npm:1.19.3"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-macos-arm64@npm:1.19.3":
-  version: 1.19.3
-  resolution: "@moonrepo/core-macos-arm64@npm:1.19.3"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-macos-x64@npm:1.19.3":
-  version: 1.19.3
-  resolution: "@moonrepo/core-macos-x64@npm:1.19.3"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-windows-x64-msvc@npm:1.19.3":
-  version: 1.19.3
-  resolution: "@moonrepo/core-windows-x64-msvc@npm:1.19.3"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@ndelangen/get-tarball@npm:^3.0.7":
   version: 3.0.9
   resolution: "@ndelangen/get-tarball@npm:3.0.9"
@@ -8599,7 +8517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.0, detect-libc@npm:^2.0.2":
+"detect-libc@npm:^2.0.0":
   version: 2.0.2
   resolution: "detect-libc@npm:2.0.2"
   checksum: a9f4ffcd2701525c589617d98afe5a5d0676c8ea82bcc4ed6f3747241b79f781d36437c59a5e855254c864d36a3e9f8276568b6b531c28d6e53b093a15703f11
@@ -11042,7 +10960,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "haohaohow@workspace:."
   dependencies:
-    "@moonrepo/cli": "npm:^1.19.3"
     "@yarnpkg/doctor": "npm:^4.0.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Previously `@moonrepo/cli` was installed, and when using proto shims for moon it would prefer using the version installed in `node_modules/.bin/moon` (it seems like it uses a heuristic of if a `.moon/` exists).