### PR TITLE
Use moon task inheritence

### DIFF
--- a/.moon/tasks/tag-chromatic.yml
+++ b/.moon/tasks/tag-chromatic.yml
@@ -1,0 +1,35 @@
+fileGroups:
+  storybookConfig:
+    - ".storybook/**/*"
+
+tasks:
+  storybook:
+    command:
+      - storybook
+      - dev
+      - --port=6006
+    local: true
+    platform: node
+  storybook-build:
+    command:
+      - storybook
+      - build
+      - --output-dir=storybook-static
+    inputs:
+      - "@group(frontend)"
+      - "@group(storybookConfig)"
+    outputs:
+      - "storybook-static/"
+    platform: node
+  chromatic:
+    command:
+      - chromatic
+      - --storybook-build-dir=storybook-static
+      - --exit-zero-on-changes
+    inputs:
+      - "storybook-static/**/*"
+      - "*.*"
+      - "$CHROMATIC_PROJECT_TOKEN"
+    deps:
+      - storybook-build
+    platform: node

--- a/.moon/tasks/tag-eslint.yml
+++ b/.moon/tasks/tag-eslint.yml
@@ -1,0 +1,6 @@
+tasks:
+  lint:
+    command:
+      - eslint
+      - .
+    platform: node

--- a/.moon/tasks/tag-prettier.yml
+++ b/.moon/tasks/tag-prettier.yml
@@ -1,0 +1,15 @@
+tasks:
+  prettier:
+    extends: prettier-check
+    args:
+      - --write
+    options:
+      mergeArgs: prepend
+    local: true
+  prettier-check:
+    command:
+      - prettier
+    args:
+      - --check
+      - .
+    platform: node

--- a/.moon/tasks/tag-sveltekit.yml
+++ b/.moon/tasks/tag-sveltekit.yml
@@ -1,0 +1,19 @@
+tasks:
+  svelte-check:
+    command:
+      - svelte-check
+      - --tsconfig
+      - ./tsconfig.json
+    deps:
+      - ~:svelte-kit-sync
+    platform: node
+  svelte-check-watch:
+    extends: svelte-check
+    args:
+      - --watch
+    local: true
+  svelte-kit-sync:
+    command:
+      - svelte-kit
+      - sync
+    platform: node

--- a/projects/frontend/moon.yml
+++ b/projects/frontend/moon.yml
@@ -19,85 +19,15 @@ tasks:
       - ~:build
     local: true
     platform: node
-  svelte-check:
-    command:
-      - svelte-check
-      - --tsconfig
-      - ./tsconfig.json
-    deps:
-      - ~:svelte-kit-sync
-    platform: node
-  svelte-kit-sync:
-    command:
-      - svelte-kit
-      - sync
-    platform: node
-  check-watch:
-    command:
-      - svelte-check
-      - --tsconfig
-      - ./tsconfig.json
-      - --watch
-    deps:
-      - ~:svelte-kit-sync
-    local: true
-    platform: node
   dev:
     command:
       - vite
       - dev
     local: true
     platform: node
-  prettier:
-    command:
-      - prettier
-      - --write
-      - .
-    platform: node
-  lint:
-    command:
-      - eslint
-      - .
-    deps:
-      - ~:prettier-check
-    platform: node
-  prettier-check:
-    command:
-      - prettier
-      - --check
-      - .
-    platform: node
-  storybook:
-    command:
-      - storybook
-      - dev
-      - --port=6006
-    inputs:
-      - "@group(frontend)"
-    local: true
-    platform: node
   storybook-build:
-    command:
-      - storybook
-      - build
-      - --output-dir=storybook-static
     inputs:
       - "@group(frontend)"
-    outputs:
-      - "storybook-static/"
-    platform: node
-  chromatic:
-    command:
-      - chromatic
-      - --storybook-build-dir=storybook-static
-      - --exit-zero-on-changes
-    inputs:
-      - "storybook-static/**/*"
-      - "*.*"
-      - "$CHROMATIC_PROJECT_TOKEN"
-    deps:
-      - storybook-build
-    platform: node
   generate:
     command:
       - "drizzle-kit"
@@ -120,3 +50,8 @@ tasks:
       - vercel
     local: true
     platform: node
+
+tags:
+  - chromatic
+  - eslint
+  - sveltekit


### PR DESCRIPTION
This utilizes project tags and task inheritence to make it easier to add more projects without the boilerplate of repeating task config. There are now four tags `chromatic`, `eslint`, `prettier`, `sveltekit` and there are corresponding task configs in `.moon/tasks/tag-*.yml` that provide configuration for each.