### PR TITLE
Do not auto EAS build on push

### DIFF
--- a/.github/workflows/expo-eas-build.yml
+++ b/.github/workflows/expo-eas-build.yml
@@ -19,12 +19,6 @@ on:
         options:
           - preview
           - production
-  push:
-    branches:
-      - "main"
-      - "releases/**"
-    paths:
-      - "projects/frontend/app.json"
 
 jobs:
   update:


### PR DESCRIPTION
There are only 15 (iOS) on the free tier, there's no point in wasting them.