### PR TITLE
Bump runtime version to 1.1.0

### DIFF
--- a/projects/frontend/app.json
+++ b/projects/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Hao",
     "slug": "hao",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "scheme": "hao",
     "runtimeVersion": {
       "policy": "appVersion"


### PR DESCRIPTION
I added some native packages like haptics which I think require a runtime update and new build.