### PR TITLE
Fix EAS Update sentry source maps upload

### DIFF
--- a/.github/workflows/expo-eas-update.yml
+++ b/.github/workflows/expo-eas-update.yml
@@ -21,6 +21,6 @@ jobs:
       - name: 🚀 Publish update
         run: |
           moon run frontend:eas -- update --auto --non-interactive
-          npx sentry-expo-upload-sourcemaps dist
+          moon run frontend:upload-sentry-source-maps
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/projects/frontend/moon.yml
+++ b/projects/frontend/moon.yml
@@ -35,6 +35,13 @@ tasks:
       - "*.json"
     outputs:
       - "dist/"
+  upload-sentry-source-maps:
+    command:
+      - npx
+      - sentry-expo-upload-sourcemaps
+      - dist
+    platform: node
+    local: true
 
 tags:
   - prettier


### PR DESCRIPTION
It was running `npx sentry-expo-upload-sourcemaps dist` in the wrong directory, so I've migrated it to Moon to avoid the goof.