### PR TITLE
Better Sentry dev mode handling

### DIFF
--- a/projects/frontend/src/app/_layout.tsx
+++ b/projects/frontend/src/app/_layout.tsx
@@ -15,11 +15,12 @@ const updateGroup =
 const routingInstrumentation = new Sentry.ReactNavigationInstrumentation();
 
 Sentry.init({
+  enabled: !__DEV__,
   dsn: "https://88e3787d84756d748f01113cc6a01fde@o4506645802909696.ingest.us.sentry.io/4506645804679168",
   // If `true`, Sentry will try to print out useful debugging information if
   // something goes wrong with sending the event. Set it to `false` in
   // production
-  debug: true,
+  debug: __DEV__,
   integrations: [
     new Sentry.ReactNativeTracing({
       routingInstrumentation,


### PR DESCRIPTION
- Don't send reports to Sentry in dev mode.
- Only use `debug` mode in dev mode.