### PR TITLE
Fix warnings for deprecated `selectable`

### DIFF
--- a/projects/frontend/src/components/FourUpQuiz.tsx
+++ b/projects/frontend/src/components/FourUpQuiz.tsx
@@ -106,15 +106,17 @@ const SubmitButton = forwardRef<
       {...(disabled ? null : rectButtonProps)}
     >
       <Text
-        selectable={false}
-        style={{
-          textTransform: "uppercase",
-          color: textColor,
-          fontSize: 16,
-          fontWeight: "bold",
-          paddingBottom: 4,
-          paddingTop: 4,
-        }}
+        style={[
+          {
+            textTransform: "uppercase",
+            color: textColor,
+            fontSize: 16,
+            fontWeight: "bold",
+            paddingBottom: 4,
+            paddingTop: 4,
+          },
+          styles.buttonText,
+        ]}
       >
         Check
       </Text>
@@ -148,7 +150,7 @@ const AnswerButton = ({
       style={{ flex: 1 }}
     >
       <View style={{ justifyContent: "center" }}>
-        <Text style={{ color: "white", fontSize: 80 }} selectable={false}>
+        <Text style={[{ color: "white", fontSize: 80 }, styles.buttonText]}>
           {text}
         </Text>
       </View>
@@ -168,5 +170,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "stretch",
     gap,
+  },
+  buttonText: {
+    userSelect: "none",
   },
 });

--- a/projects/frontend/src/components/SectionHeaderButton.tsx
+++ b/projects/frontend/src/components/SectionHeaderButton.tsx
@@ -1,4 +1,4 @@
-import { Text } from "react-native";
+import { StyleSheet, Text } from "react-native";
 import { RectButton } from "./RectButton";
 import { PropsOf } from "./types";
 
@@ -22,29 +22,28 @@ export function SectionHeaderButton({
       color={rectButtonProps.color ?? "#333"}
     >
       <Text
-        style={{
-          color: "white",
-          fontSize: 10,
-          fontWeight: "bold",
-          opacity: 0.8,
-          textTransform: "uppercase",
-          marginBottom: 5,
-          alignSelf: "flex-start",
-        }}
-        selectable={false}
+        style={[
+          styles.text,
+          {
+            fontSize: 10,
+            opacity: 0.8,
+            textTransform: "uppercase",
+            marginBottom: 5,
+          },
+        ]}
       >
         {title}
       </Text>
-      <Text
-        style={{
-          color: "white",
-          fontWeight: "bold",
-          alignSelf: "flex-start",
-        }}
-        selectable={false}
-      >
-        {subtitle}
-      </Text>
+      <Text style={styles.text}>{subtitle}</Text>
     </RectButton>
   );
 }
+
+const styles = StyleSheet.create({
+  text: {
+    userSelect: "none",
+    color: "white",
+    fontWeight: "bold",
+    alignSelf: "flex-start",
+  },
+});


### PR DESCRIPTION
Weirdly `userSelect: "none"` only works within `StyleSheet.create(…)`, doing it in inline styles on the element doesn't work.