### PR TITLE
Add progress bar streak colors

### DIFF
--- a/projects/frontend/app.json
+++ b/projects/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Hao",
     "slug": "hao",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "scheme": "hao",
     "runtimeVersion": {
       "policy": "appVersion"

--- a/projects/frontend/package.json
+++ b/projects/frontend/package.json
@@ -14,6 +14,7 @@
     "expo-haptics": "~12.8.1",
     "expo-image": "~1.10.6",
     "expo-insights": "~0.6.1",
+    "expo-linear-gradient": "^12.7.2",
     "expo-linking": "~6.2.2",
     "expo-router": "~3.4.8",
     "expo-splash-screen": "^0.26.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9117,6 +9117,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-linear-gradient@npm:^12.7.2":
+  version: 12.7.2
+  resolution: "expo-linear-gradient@npm:12.7.2"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/08701b3aaad7a063da034fe778821453d0bde50b62d54a6a131ab7ffd270422e9f12461846350a6e6bad0165cdf286150ad86e1307fc1712aabe16e0513ec937
+  languageName: node
+  linkType: hard
+
 "expo-linking@npm:~6.2.2":
   version: 6.2.2
   resolution: "expo-linking@npm:6.2.2"
@@ -9621,6 +9630,7 @@ __metadata:
     expo-haptics: "npm:~12.8.1"
     expo-image: "npm:~1.10.6"
     expo-insights: "npm:~0.6.1"
+    expo-linear-gradient: "npm:^12.7.2"
     expo-linking: "npm:~6.2.2"
     expo-router: "npm:~3.4.8"
     expo-splash-screen: "npm:^0.26.4"


### PR DESCRIPTION
The challenging part here was getting the gradient to not change, but rather be static and revealed gradually. I played around with a few options, initially tried a mask but `MaskedView` only works on mobile (not web). Instead tried the `onLayout` approach which meant the gradient could have an absolute width and then its container have `overflow: hidden` to mask it.