### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/projects/frontend/app.json
+++ b/projects/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Hao",
     "slug": "hao",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "scheme": "hao",
     "runtimeVersion": {
       "policy": "appVersion"


### PR DESCRIPTION
lodash-es was swapped for lodash, so it probably broke things.