### PR TITLE
Remove `SafeAreaView`

### DIFF
--- a/projects/frontend/eslint.config.mjs
+++ b/projects/frontend/eslint.config.mjs
@@ -90,6 +90,20 @@ export default tseslint.config(
       ],
       "one-var": ["error", "never"],
 
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "react-native",
+              importNames: ["SafeAreaView"],
+              message:
+                "Please use `useSafeAreaInsets` from `react-native-safe-area-context` instead.",
+            },
+          ],
+        },
+      ],
+
       //
       // eslint-plugin-import
       //

--- a/projects/frontend/src/app/index.tsx
+++ b/projects/frontend/src/app/index.tsx
@@ -4,15 +4,8 @@ import { Link } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar as ExpoStatusBar } from "expo-status-bar";
 import { useCallback, useEffect } from "react";
-import {
-  ColorValue,
-  SafeAreaView,
-  ScrollView,
-  StatusBar,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { ColorValue, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CircleButton } from "../components/CircleButton";
 import { useReplicache } from "../components/ReplicacheContext";
 import { RootView } from "../components/RootView";
@@ -27,6 +20,7 @@ import {
 } from "../components/styles";
 
 export default function IndexPage() {
+  const insets = useSafeAreaInsets();
   const [fontsLoaded, fontError] = useFonts({
     "MaShanZheng-Regular": require("../../assets/fonts/MaShanZheng-Regular.ttf"),
     "NotoSerifSC-Medium": require("../../assets/fonts/NotoSerifSC-Medium.otf"),
@@ -69,15 +63,14 @@ export default function IndexPage() {
     <RootView
       backgroundColor="tomato"
       onLayout={onLayoutRootView}
-      style={styles.container}
+      style={[styles.container, { paddingTop: insets.top }]}
     >
-      <SafeAreaView
+      <View
         style={{
           flex: 1,
           width: "100%",
           alignItems: "center",
           justifyContent: "center",
-          paddingTop: StatusBar.currentHeight,
         }}
       >
         <ScrollView style={{ flex: 1 }}>
@@ -131,7 +124,7 @@ export default function IndexPage() {
             />
           </View>
         </ScrollView>
-      </SafeAreaView>
+      </View>
       <ExpoStatusBar style="auto" />
     </RootView>
   );

--- a/projects/frontend/src/app/learn/quiz.tsx
+++ b/projects/frontend/src/app/learn/quiz.tsx
@@ -1,12 +1,14 @@
 import { StatusBar as ExpoStatusBar } from "expo-status-bar";
 import { useEffect } from "react";
-import { SafeAreaView, StatusBar, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FourUpQuiz } from "../../components/FourUpQuiz";
 import { useReplicache } from "../../components/ReplicacheContext";
 import { RootView } from "../../components/RootView";
 
 export default function QuizPage() {
   const r = useReplicache();
+  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     // eslint-disable-next-line no-console
@@ -15,13 +17,13 @@ export default function QuizPage() {
 
   return (
     <RootView backgroundColor="#161F23" style={styles.container}>
-      <SafeAreaView
+      <View
         style={{
           flex: 1,
           width: "100%",
           flexDirection: "row",
           justifyContent: "center",
-          paddingTop: StatusBar.currentHeight, // Necessary for Android
+          paddingTop: insets.top,
         }}
       >
         <View style={{ maxWidth: 600, flex: 1 }}>
@@ -59,7 +61,7 @@ export default function QuizPage() {
           />
         </View>
         <ExpoStatusBar style="auto" />
-      </SafeAreaView>
+      </View>
     </RootView>
   );
 }


### PR DESCRIPTION
Replace it with `react-native-safe-area-context` instead. This gives more flexibility (e.g. allows using `<LinearGradient>` to the top of the screen.)