### PR TITLE
Downgrade Node.js to v21

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -1,5 +1,5 @@
 node:
-  version: "22.1"
+  version: "~21.6"
   packageManager: "yarn"
   yarn:
     version: "4.2.2"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ proto use
 proto upgrade
 ```
 
+## Upgrading Node.js
+
+Edit `.moon/toolchain.yml` edit `node.version`.
+
+```
+moon run node-version
+```
+
+Moon will automatically synchronize `package.json` `engines.node`, and it will
+use proto to download and install the right version of Node.js.
+
 ## Upgrading a transitive Yarn dependency (e.g. for security patch)
 
 A normal `yarn up ___` won't work if no workspace depends on it directly, so you

--- a/moon.yml
+++ b/moon.yml
@@ -10,6 +10,12 @@ tasks:
       - doctor
       - .
     platform: node
+  node-version:
+    command:
+      - node
+      - "--version"
+    platform: node
+    local: true
   yarn-constraints:
     command:
       - yarn

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typescript": "^5.4.5"
   },
   "engines": {
-    "node": "~22.1"
+    "node": "~21.6"
   },
   "resolutions": {
     "@testing-library/user-event@npm:14.3.0": "npm:@testing-library/user-event@^14.5.0",


### PR DESCRIPTION
This fixes an issue with Expo where it was logging warnings:

```
Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
```

It would output one line for each `_layout.tsx` in the project. The issue only seems to have started in Node.js 22. Another work-around is to convert these files to CommonJS with `require()` and `module.exports =`, but that will create more refactoring burden later. There's a reddit thread about it too https://www.reddit.com/r/expo/comments/1cvhzlr/constantly_getting_a_warning_to_load_an_es_module/

Instead for now downgrading to v21.

Also added instructions for how to change the Node.js version, and reported a bug to Moon for it not respecting ancestor `.prototools` for the Node.js version.
https://discord.com/channels/974160221452763146/974160221452763149/1243515551326933002