### PR TITLE
Remove hard-coded TEST_LICENSE_KEY value

### DIFF
--- a/projects/frontend/.env.test
+++ b/projects/frontend/.env.test
@@ -1,2 +1,1 @@
-# Taken from `import { TEST_LICENSE_KEY } from 'replicache';`
-EXPO_PUBLIC_REPLICACHE_LICENSE_KEY="This key only good for automated testing"
+EXPO_PUBLIC_REPLICACHE_LICENSE_KEY="TEST_LICENSE_KEY"

--- a/projects/frontend/src/env.ts
+++ b/projects/frontend/src/env.ts
@@ -1,7 +1,11 @@
+import { TEST_LICENSE_KEY } from "replicache";
 import z from "zod";
 
-const parseString = (x: unknown) => z.string().min(1).parse(x);
+const nonEmptyString = z.string().min(1);
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const parseString = (x: unknown) => nonEmptyString.parse(x);
 
-export const replicacheLicenseKey = parseString(
-  process.env.EXPO_PUBLIC_REPLICACHE_LICENSE_KEY,
-);
+export const replicacheLicenseKey = nonEmptyString
+  // The special value `TEST_LICENSE_KEY` swaps to the test key from replicache.
+  .transform((x) => (x === "TEST_LICENSE_KEY" ? TEST_LICENSE_KEY : x))
+  .parse(process.env.EXPO_PUBLIC_REPLICACHE_LICENSE_KEY);


### PR DESCRIPTION
Instead using a sentinel value and swap it out at runtime with the value from the `replicache` package. This makes it less fragile in the case where replicache changes the value of `TEST_LICENSE_KEY`.