### PR TITLE
Replicache refactorings/experiments

### DIFF
--- a/projects/frontend/src/app/index.tsx
+++ b/projects/frontend/src/app/index.tsx
@@ -6,8 +6,9 @@ import {
   SectionHeaderButtonProps,
 } from "@/components/SectionHeaderButton";
 import { GradientAqua, GradientPurple, GradientRed } from "@/components/styles";
-import { hanziKeyedSkillToKey } from "@/data/marshal";
-import { Skill, SkillType } from "@/data/model";
+import { hanziSkillToKey } from "@/data/marshal";
+import { SkillType } from "@/data/model";
+import { addHanziSkill, incrementCounter } from "@/data/mutators";
 import * as Sentry from "@sentry/react-native";
 import { useFonts } from "expo-font";
 import { Link } from "expo-router";
@@ -41,7 +42,7 @@ export default function IndexPage() {
 
         const shouldSeed = await r.query(async (tx) => {
           const result = await tx.get(
-            hanziKeyedSkillToKey({
+            hanziSkillToKey({
               type: SkillType.HanziWordToEnglish,
               hanzi,
             }),
@@ -52,11 +53,10 @@ export default function IndexPage() {
         if (shouldSeed) {
           // eslint-disable-next-line no-console
           console.log(`Adding skill…`);
-          const skill: Skill = {
+          await addHanziSkill(r, {
             type: SkillType.HanziWordToEnglish,
             hanzi,
-          };
-          await r.mutate.addSkill({ skill });
+          });
         }
 
         await r.query(async (tx) => {
@@ -82,7 +82,7 @@ export default function IndexPage() {
           const counter = await tx.get(`counter`);
           // eslint-disable-next-line no-console
           console.log(`counter =`, counter);
-          r.mutate.incrementCounter().catch((e: unknown) => {
+          incrementCounter(r).catch((e: unknown) => {
             // eslint-disable-next-line no-console
             console.error(e);
           });

--- a/projects/frontend/src/components/QuizDeck.tsx
+++ b/projects/frontend/src/components/QuizDeck.tsx
@@ -1,4 +1,5 @@
 import { Question, QuestionFlag, QuestionType } from "@/data/model";
+import { saveSkillRating } from "@/data/mutators";
 import { Rating } from "@/util/fsrs";
 import { NavigationContainer, useTheme } from "@react-navigation/native";
 import {
@@ -102,12 +103,14 @@ export const QuizDeck = ({
 
     if (currentQuestion !== undefined) {
       if (currentQuestion.type === QuestionType.OneCorrectPair) {
-        r?.mutate
-          .updateSkill({ skill: currentQuestion.skill, rating })
-          .catch((e: unknown) => {
-            // eslint-disable-next-line no-console
-            console.error(`failed to update skill`, e);
-          });
+        if (r) {
+          saveSkillRating(r, currentQuestion.skill, rating).catch(
+            (e: unknown) => {
+              // eslint-disable-next-line no-console
+              console.error(`failed to update skill`, e);
+            },
+          );
+        }
       }
 
       setStreakCount((prev) => (success ? prev + 1 : 0));

--- a/projects/frontend/src/data/marshal.test.ts
+++ b/projects/frontend/src/data/marshal.test.ts
@@ -1,17 +1,19 @@
 import assert from "node:assert";
 import test from "node:test";
 import {
-  marshalReviewJson,
+  marshalSkillJson,
   marshalSrsStateJson,
-  unmarshalReviewJson,
+  unmarshalSkillJson,
   unmarshalSrsStateJson,
 } from "./marshal";
-import { Review, SrsState, SrsType } from "./model";
+import { Skill as Review, SkillType, SrsState, SrsType } from "./model";
 
 // TODO: data generator fuzzy testing
 
-void test(`Review`, () => {
-  const review: Review = {
+void test(`Skill`, () => {
+  const skill: Review = {
+    type: SkillType.HanziWordToEnglish,
+    hanzi: `火`,
     created: new Date(),
     srs: {
       type: SrsType.Null,
@@ -19,10 +21,7 @@ void test(`Review`, () => {
     due: new Date(),
   };
 
-  assert.deepStrictEqual(
-    review,
-    unmarshalReviewJson(marshalReviewJson(review)),
-  );
+  assert.deepStrictEqual(skill, unmarshalSkillJson(marshalSkillJson(skill)));
 });
 
 void test(`SrsState`, () => {

--- a/projects/frontend/src/data/migrations/v2.ts
+++ b/projects/frontend/src/data/migrations/v2.ts
@@ -1,0 +1,10 @@
+// don't allow an imports of types or marshalling etc.
+import { MutatorDefs } from "replicache";
+
+export const migrate = {
+  async migrate1to2(tx) {
+    // read all `/s/he/<hanzi>`
+    // do something …
+    await tx.get(`stub`);
+  },
+} satisfies MutatorDefs;

--- a/projects/frontend/src/data/model.ts
+++ b/projects/frontend/src/data/model.ts
@@ -1,5 +1,3 @@
-import type z from "zod";
-
 export enum SrsType {
   Null,
   FsrsFourPointFive,
@@ -17,7 +15,7 @@ export interface SrsFourPointFiveState {
 
 export type SrsState = SrsNullState | SrsFourPointFiveState;
 
-export interface Review {
+export interface SkillBase {
   created: Date;
   srs: SrsState;
   due: Date;
@@ -33,16 +31,21 @@ export enum SkillType {
   ImageToHanzi,
 }
 
-// export type HanziKeyedSkill = z.infer<typeof hanziKeyedSkillSchema>;
-
-export interface HanziKeyedSkill {
-  type: SkillType;
+export interface HanziSkill extends SkillBase {
+  type:
+    | SkillType.HanziWordToEnglish
+    | SkillType.HanziWordToPinyinInitial
+    | SkillType.HanziWordToPinyinFinal
+    | SkillType.HanziWordToPinyinTone
+    | SkillType.EnglishToHanzi
+    | SkillType.PinyinToHanzi
+    | SkillType.ImageToHanzi;
   hanzi: string;
 }
 
-export type Skill = HanziKeyedSkill;
+export type HanziSkillKey = Pick<HanziSkill, `type` | `hanzi`>;
 
-export type SkillKey = string & z.BRAND<`SkillKey`>;
+export type Skill = HanziSkill;
 
 export enum QuestionFlag {
   WeakWord,

--- a/projects/frontend/src/data/mutators.ts
+++ b/projects/frontend/src/data/mutators.ts
@@ -1,0 +1,140 @@
+import { Rating, nextReview } from "@/util/fsrs";
+import { MutatorDefs, Replicache } from "replicache";
+import {
+  MarshaledSkill,
+  MarshaledSkillKey,
+  hanziSkillToKey,
+  marshalSkill,
+  marshalSkillJson,
+  unmarshalSkillJson,
+} from "./marshal";
+import { HanziSkillKey, SrsType } from "./model";
+
+// Schema
+//
+// Version 2
+//
+// Changes:
+//
+// - Move
+//
+// Version 1
+//
+// - `/s/he/<hanzi>`
+// - `/s/hpi/<hanzi>`
+// - `/s/hpf/<hanzi>`
+// - `/s/hpt/<hanzi>`
+// - `/s/eh/<hanzi>`
+// - `/s/ph/<hanzi>`
+// - `/s/ih/<hanzi>`
+
+export const mutators = {
+  async incrementCounter(tx, options?: { quantity?: number }) {
+    const quantity = options?.quantity ?? 1;
+    const counter = await tx.get<number>(`counter`);
+    await tx.set(`counter`, (counter ?? 0) + quantity);
+  },
+
+  async addSkill(
+    tx,
+    {
+      s: [key, value],
+    }: {
+      // TODO: this isn't just storing the intent, it's storing specific values,
+      // is that okay? maybe… IDs need to be passed through, mutators should be
+      // deterministic (but doesn't mean client/server need to be the same).
+      s: MarshaledSkill;
+    },
+  ) {
+    // TODO: check if it's already been added by another client
+    await tx.set(key, value);
+  },
+
+  // TODO: rename to "skill reviewed" or something more declarative of the
+  // intent so ti's not just last write wins.
+  async updateSkill(
+    tx,
+    {
+      k: key,
+      r: rating,
+      n: now,
+    }: { k: MarshaledSkillKey; r: Rating; n: number },
+  ): Promise<void> {
+    const skillValue = await tx.get(key);
+    if (skillValue === undefined) {
+      return;
+    }
+
+    const skill = unmarshalSkillJson([key, skillValue]);
+    if (skill.srs.type !== SrsType.FsrsFourPointFive) {
+      return;
+    }
+
+    // - TODO: check that the last state created before this result.
+    // - TODO: store the results a separate key prefix and recalculate to merge
+    //   the results each time a new result is created.
+    const s = nextReview(
+      {
+        created: skill.created,
+        stability: skill.srs.stability,
+        difficulty: skill.srs.difficulty,
+        due: skill.due,
+      },
+      // TODO: pass `now` here.
+      rating,
+    );
+    const [, value] = marshalSkillJson({
+      ...skill,
+      created: new Date(now),
+      srs: {
+        type: SrsType.FsrsFourPointFive,
+        stability: s.stability,
+        difficulty: s.difficulty,
+      },
+      due: s.due,
+    });
+    // eslint-disable-next-line no-console
+    console.log(`updating ${key} to `, value);
+    await tx.set(key, value);
+  },
+} satisfies MutatorDefs;
+
+// TODO: ban new Date() (with no args) in this file.
+
+// TODO: function to wrap all mutators to do the schema version check first?
+
+type HHReplicache = Replicache<typeof mutators>;
+
+export async function addHanziSkill(r: HHReplicache, skill: HanziSkillKey) {
+  const { stability, difficulty } = nextReview(null, Rating.Again);
+  const now = new Date();
+
+  await r.mutate.addSkill({
+    s: marshalSkill({
+      ...skill,
+      created: now,
+      srs: {
+        type: SrsType.FsrsFourPointFive,
+        stability,
+        difficulty,
+      },
+      due: now,
+    }),
+  });
+}
+
+export async function saveSkillRating(
+  r: HHReplicache,
+  skill: HanziSkillKey,
+  rating: Rating,
+) {
+  await r.mutate.updateSkill({
+    n: Date.now(),
+    k: hanziSkillToKey(skill),
+    r: rating,
+  });
+}
+
+export async function incrementCounter(r: HHReplicache) {
+  await r.mutate.incrementCounter();
+}

--- a/projects/frontend/src/util/ExpoSQLiteKVStore.ts
+++ b/projects/frontend/src/util/ExpoSQLiteKVStore.ts
@@ -97,7 +97,9 @@ export class ExpoSQLiteKVStore implements ExperimentalKVStore {
   }
 }
 
-let txId = 0;
+// For debugging purposes, a sequentially incrementing transaction number (not
+// connection specific).
+const txIds: Record<string, number> = {};
 
 export class ExpoSQLiteKVStoreReadImpl implements ExperimentalKVRead {
   protected _db: SQLite.SQLiteDatabase | null;
@@ -107,7 +109,7 @@ export class ExpoSQLiteKVStoreReadImpl implements ExperimentalKVRead {
     db: SQLite.SQLiteDatabase,
     public readonly onRelease: () => void,
   ) {
-    this._txId = txId++;
+    this._txId = txIds[db.databaseName] = (txIds[db.databaseName] ?? 0) + 1;
     log?.(`KV[${this._txId.toString()}]#constructor()`);
     this._db = db;
   }


### PR DESCRIPTION
- Make mutators use marshaled values (since these are sent over the network and saved in the local DB until flushed).
- Add mutation functions (separate from `r.mutate.*`) with non-marshaled API.
- Remove dynamic date calculation in replicache mutators (mutators should be deterministic so that during rebase they produce the same result).
- Make DB debug logging transaction IDs keyed off the database name (not just the connection).